### PR TITLE
chore(pre-commit): exclude poetry.lock from codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
     rev: v2.4.2
     hooks:
       - id: codespell
+        exclude: ^poetry\.lock$
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v2.1.0
     hooks:


### PR DESCRIPTION
Codespell flags false positives inside poetry.lock; excluding the lockfile so the hook stays useful for real source files.