### PR TITLE
ci: replace per-commit conventional commits check with pr title check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,26 @@ jobs:
           python-version: 3.x
       - uses: pre-commit/action@v3.0.1
 
-  # Make sure commit messages follow the conventional commits convention:
+  # Make sure the PR title follows the conventional commits convention:
   # https://www.conventionalcommits.org
-  commitlint:
-    name: Lint Commit Messages
+  # PRs are squash-merged, so the PR title becomes the commit on main and
+  # drives python-semantic-release's version bump.
+  pr-title:
+    name: Lint PR Title
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: amannn/action-semantic-pull-request@v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v6.2.1
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            starts with a lowercase character.
 
   test:
     strategy:
@@ -75,7 +85,6 @@ jobs:
     needs:
       - test
       - lint
-      - commitlint
 
     runs-on: ubuntu-latest
     environment: release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,6 @@ ci:
   autoupdate_commit_msg: "chore(pre-commit.ci): pre-commit autoupdate"
 
 repos:
-  - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.16.2
-    hooks:
-      - id: commitizen
-        stages: [commit-msg]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,8 +1,0 @@
-export default {
-  extends: ["@commitlint/config-conventional"],
-  rules: {
-    "header-max-length": [0, "always", Infinity],
-    "body-max-line-length": [0, "always", Infinity],
-    "footer-max-line-length": [0, "always", Infinity],
-  },
-};


### PR DESCRIPTION
## Summary
- PRs here are squash merged, so only the PR title lands on main; the per-commit commitlint job and the commitizen pre-commit hook check intermediate commits that never matter.
- Swap commitlint for amannn/action-semantic-pull-request to validate the PR title; subjectPattern preserves the lowercase first-character rule.
- Drop commitlint.config.mjs and the commitizen pre-commit hook, and drop commitlint from the release job's needs.
- Mirrors python-zeroconf/python-zeroconf#1740 and the same fix in dbus-fast.

## Test plan
- [x] yaml.safe_load on ci.yml and .pre-commit-config.yaml parses cleanly
- [ ] pr-title CI job runs against this PR